### PR TITLE
Implement resolve_failed_matches, add flag for ignoring cached spotify playlists

### DIFF
--- a/libsync/create_spotify_playlists.py
+++ b/libsync/create_spotify_playlists.py
@@ -15,7 +15,6 @@ SKIP_CREATE_SPOTIFY_PLAYLISTS = False
 USE_SAVED_DB_PLAYLISTS = False
 
 
-
 def create_spotify_playlists(
     playlist_id_map: dict[str, str],
     rekordbox_playlists: list[RekordboxPlaylist],
@@ -88,7 +87,8 @@ def create_spotify_playlists(
             tracks_uris_to_add = [
                 rekordbox_to_spotify_map[track_id]
                 for track_id in playlist.tracks
-                if track_id in rekordbox_to_spotify_map and rekordbox_to_spotify_map[track_id] is not None
+                if track_id in rekordbox_to_spotify_map
+                and rekordbox_to_spotify_map[track_id] is not None
             ]
 
             pages = [

--- a/libsync/get_rekordbox_library.py
+++ b/libsync/get_rekordbox_library.py
@@ -14,9 +14,7 @@ from rekordbox_library import (
 )
 
 
-def get_rekordbox_library(
-    rekordbox_xml_path: str, include_loose_songs: bool
-) -> RekordboxLibrary:
+def get_rekordbox_library(rekordbox_xml_path: str, include_loose_songs: bool) -> RekordboxLibrary:
     """_summary_
 
     Args:
@@ -26,9 +24,7 @@ def get_rekordbox_library(
         RekordboxLibrary: _description_
     """
 
-    logging.info(
-        f"running get_rekordbox_library with rekordbox_xml_path: {rekordbox_xml_path}"
-    )
+    logging.info(f"running get_rekordbox_library with rekordbox_xml_path: {rekordbox_xml_path}")
 
     tree = ET.parse(rekordbox_xml_path)
     root = tree.getroot()
@@ -49,9 +45,7 @@ def get_rekordbox_library(
     while len(nodes) >= 1:
         node = nodes[0]
         node_type = (
-            RekordboxNodeType.FOLDER
-            if node.get("Type") == "0"
-            else RekordboxNodeType.PLAYLIST
+            RekordboxNodeType.FOLDER if node.get("Type") == "0" else RekordboxNodeType.PLAYLIST
         )
 
         logging.debug(f"running loop with nodes: {nodes}, " + f"nodes[0]: {nodes[0]}, ")
@@ -85,6 +79,4 @@ def get_rekordbox_library(
         )
 
     logging.info("done getting rekordbox library")
-    return RekordboxLibrary(
-        collection=rekordbox_collection, playlists=rekordbox_playlists
-    )
+    return RekordboxLibrary(collection=rekordbox_collection, playlists=rekordbox_playlists)

--- a/libsync/get_spotify_matches.py
+++ b/libsync/get_spotify_matches.py
@@ -24,6 +24,7 @@ DEBUG_SIMILARITY = False
 MINIMUM_SIMILARITY_THRESHOLD = 0.95
 RESOLVE_FAILED_MATCHES = True
 
+
 def get_spotify_matches(
     rekordbox_to_spotify_map: dict[str, str],
     cached_search_search_results: dict,
@@ -76,20 +77,19 @@ def get_spotify_matches(
             rekordbox_to_spotify_map[rb_track.id] = best_match_uri
 
     if RESOLVE_FAILED_MATCHES:
-        rekordbox_to_spotify_map = resolve_failed_matches(failed_matches,rekordbox_to_spotify_map)
+        rekordbox_to_spotify_map = resolve_failed_matches(failed_matches, rekordbox_to_spotify_map)
     else:
         export_failed_matches_to_file(failed_matches)
 
     return rekordbox_to_spotify_map
 
 
-
-def resolve_failed_matches(failed_matches,rekordbox_to_spotify_map):
+def resolve_failed_matches(failed_matches, rekordbox_to_spotify_map):
     for rb_track in failed_matches:
         correct_uri = get_correct_spotify_url_from_user(rb_track)
         if correct_uri:
             # correct_url = convert_uri_to_url(correct_uri)
-            rekordbox_to_spotify_map[rb_track.id] = (correct_uri)
+            rekordbox_to_spotify_map[rb_track.id] = correct_uri
 
         elif check_if_track_should_be_ignored_in_future_from_user(rb_track):
             rekordbox_to_spotify_map[rb_track.id] = None
@@ -114,42 +114,64 @@ def export_failed_matches_to_file(failed_matches: list[RekordboxTrack]):
         for line in failed_matches:
             file.write(f"\t{line}\n")
 
-def check_if_spotify_url_is_valid(spotify_url)->bool:
-    #TODO: implement this
+
+def check_if_spotify_url_is_valid(spotify_url) -> bool:
+    # TODO: implement this
     return True
 
 
 def get_correct_spotify_url_from_user(rb_track):
     # TODO: consider using click for user input https://click.palletsprojects.com/en/8.1.x/
-    correct_spotify_url_input = input(f"Couldn't find a good match for {rb_track}. Please paste the matching spotify link here (press 'Enter' to skip): ").lower().strip(" ")
+    correct_spotify_url_input = (
+        input(
+            f"Couldn't find a good match for {rb_track}. Please paste the matching spotify link here (press 'Enter' to skip): "
+        )
+        .lower()
+        .strip(" ")
+    )
     while True:
-        if correct_spotify_url_input=="" or check_if_spotify_url_is_valid(correct_spotify_url_input):
+        if correct_spotify_url_input == "" or check_if_spotify_url_is_valid(
+            correct_spotify_url_input
+        ):
             return correct_spotify_url_input
 
-        correct_spotify_url_input = input(f"The given response is invalid. Please try again (press 'Enter' to skip): ").lower().strip("")
+        correct_spotify_url_input = (
+            input(f"The given response is invalid. Please try again (press 'Enter' to skip): ")
+            .lower()
+            .strip("")
+        )
 
 
 def check_if_track_should_be_ignored_in_future_from_user(rb_track):
-    ignore_track_in_future_input = input("No link entered. Would you like lib-sync to ignore this track in the future? [y/n]: ").lower().strip(" ")
+    ignore_track_in_future_input = (
+        input(
+            "No link entered. Would you like lib-sync to ignore this track in the future? [y/n]: "
+        )
+        .lower()
+        .strip(" ")
+    )
     while True:
-        if ignore_track_in_future_input in {"y","yes","ye"}:
+        if ignore_track_in_future_input in {"y", "yes", "ye"}:
             return True
-        elif ignore_track_in_future_input in {"n","no"}:
+        elif ignore_track_in_future_input in {"n", "no"}:
             return False
 
-        ignore_track_in_future_input = input("The given response is invalid. Please enter 'y' or 'n'.\nWould you like lib-sync to ignore this track in the future? [y/n]: ").lower().strip(" ")
+        ignore_track_in_future_input = (
+            input(
+                "The given response is invalid. Please enter 'y' or 'n'.\nWould you like lib-sync to ignore this track in the future? [y/n]: "
+            )
+            .lower()
+            .strip(" ")
+        )
+
 
 def remove_original_mix(song_title: str) -> str:
-    trimmed_song_title = re.sub(
-        r"[\(\[]original mix[\)\]]", "", song_title, flags=re.IGNORECASE
-    )
+    trimmed_song_title = re.sub(r"[\(\[]original mix[\)\]]", "", song_title, flags=re.IGNORECASE)
     return trimmed_song_title
 
 
 def remove_extended_mix(song_title: str) -> str:
-    trimmed_song_title = re.sub(
-        r"[\(\[]extended mix[\)\]]", "", song_title, flags=re.IGNORECASE
-    )
+    trimmed_song_title = re.sub(r"[\(\[]extended mix[\)\]]", "", song_title, flags=re.IGNORECASE)
     return trimmed_song_title
 
 
@@ -184,10 +206,7 @@ def get_spotify_search_results(
 def get_artists_from_rekordbox_track(
     rekordbox_track: RekordboxTrack,
 ):
-    return [
-        artist.strip()
-        for artist in re.split(ARTIST_LIST_DELIMITERS, rekordbox_track.artist)
-    ]
+    return [artist.strip() for artist in re.split(ARTIST_LIST_DELIMITERS, rekordbox_track.artist)]
 
 
 def get_name_varieties_from_track_name(name: str):
@@ -214,9 +233,7 @@ def get_spotify_queries_from_rekordbox_track(
             # try artist first, then song name first
             for ordered_search_terms in [search_terms, reversed(search_terms)]:
                 # remove punctuation
-                ordered_search_terms = [
-                    strip_punctuation(term) for term in ordered_search_terms
-                ]
+                ordered_search_terms = [strip_punctuation(term) for term in ordered_search_terms]
                 # build query
                 query = urllib.parse.quote(" ".join(ordered_search_terms))
                 queries.append(query)
@@ -253,9 +270,7 @@ def try_to_find_perfect_match_and_fall_back_on_user_input(
             artists = [artist["name"] for artist in track["artists"]]
             track_name = track["name"]
             # track_uri = track["uri"]
-            potential_match_strings[
-                i
-            ] = f"{track_name} - Artist(s): {artists} Album: {album}"
+            potential_match_strings[i] = f"{track_name} - Artist(s): {artists} Album: {album}"
             i += 1
 
         potential_match_strings[11] = "See next page of results"
@@ -264,12 +279,8 @@ def try_to_find_perfect_match_and_fall_back_on_user_input(
 
         for index, track_string in potential_match_strings.items():
             print(f"  {index}: {track_string}")
-        selected_match_i = int(
-            input("Please select an an option from the list [0-11]: ")
-        )
-        print(
-            f"Selected option {selected_match_i}: {potential_match_strings[selected_match_i]}"
-        )
+        selected_match_i = int(input("Please select an an option from the list [0-11]: "))
+        print(f"Selected option {selected_match_i}: {potential_match_strings[selected_match_i]}")
         if not selected_match_i:
             print("This track will be ignored and left out of spotify playlist.)")
             return None
@@ -299,9 +310,7 @@ def get_string_similarity(string_1: str, string_2: str) -> float:
     return SequenceMatcher(None, string_1.lower(), string_2.lower()).ratio()
 
 
-def find_best_track_match_uri(
-    rekordbox_track: RekordboxTrack, spotify_search_results: dict
-):
+def find_best_track_match_uri(rekordbox_track: RekordboxTrack, spotify_search_results: dict):
     logging.debug(
         f"running find_best_track_match_uri with rekordbox_track:\n{pprint.pformat(rekordbox_track)}"
     )
@@ -329,12 +338,8 @@ def find_best_track_match_uri(
         ]
 
         # artist similarity
-        spotify_artist_list = [
-            artist["name"] for artist in spotify_track_option["artists"]
-        ]
-        rekordbox_artist_list = get_artists_from_rekordbox_track(
-            rekordbox_track=rekordbox_track
-        )
+        spotify_artist_list = [artist["name"] for artist in spotify_track_option["artists"]]
+        rekordbox_artist_list = get_artists_from_rekordbox_track(rekordbox_track=rekordbox_track)
 
         artist_similarities = [
             get_string_similarity(spotify_artist, rekordbox_artist)

--- a/libsync/sync_rekordbox_to_spotify.py
+++ b/libsync/sync_rekordbox_to_spotify.py
@@ -51,9 +51,7 @@ def sync_rekordbox_to_spotify(
             )
     except FileNotFoundError as error:
         logging.exception(error)
-        print(
-            f"couldn't find database: '{rekordbox_xml_path}'. creating new database from scratch"
-        )
+        print(f"couldn't find database: '{rekordbox_xml_path}'. creating new database from scratch")
     except KeyError as error:
         logging.exception(error)
         print(


### PR DESCRIPTION
1. If RESOLVE_FAILED_MATCHES global is set to true, the user will be prompted to enter a URL for each failed match.
2. If the user decides to skip a certain track, then the user will have the option to ignored that track in the future
3. constant USE_SAVED_DB_PLAYLISTS allows dev to delete playlists on spotify manually for debugging purposes
