### PR TITLE
Check for None in search results entries

### DIFF
--- a/libsync/spotify/get_spotify_matches.py
+++ b/libsync/spotify/get_spotify_matches.py
@@ -175,7 +175,7 @@ def get_spotify_search_results(
     search_result_tracks = {}
     queries = get_spotify_queries_from_rb_track(rb_track)
     for query in queries:
-        if not query: #TODO: figure out what is causing empty queries and remove them from the list
+        if not query:  # TODO: figure out what is causing empty queries and remove them from the list
             continue
         if query in cached_spotify_search_results:
             results = cached_spotify_search_results[query]
@@ -194,6 +194,12 @@ def get_spotify_search_results(
                 )
 
         for track in results:
+            if track is None:
+                logger.warning(
+                    f"track in spotify search results is None! This is unexpected and may indicate an issue with data returned from Spofify API.\nResults: {results}."
+                )
+                continue
+
             search_result_tracks[track["uri"]] = track
 
     return search_result_tracks


### PR DESCRIPTION
**Description**
This change is to address anomaly where an item in the results dict is None. This is unexpected response from the Spotify API - rather, it would be expected for the search request to return None for the entire query OR an empty list.

For now, a log message is added, and the loop continues such that this anomaly does not prevent `sync` from completing.

---

**Stack**:
- #20 ⬅
- #19


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*